### PR TITLE
Prevent race conditions on postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ language: ruby
 rvm:
   - 1.9.3
   - ruby-head
+
+env:
+  - DB=sqlite
+  - DB=postgresql
+
+before_script:
+  - rake db:create

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,12 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
+group :development, :test do
+  gem 'sqlite3'
+  # gem 'mysql2'
+  gem 'pg'
+end
+
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing

--- a/Rakefile
+++ b/Rakefile
@@ -31,5 +31,13 @@ Rake::TestTask.new(:test) do |t|
   t.verbose = false
 end
 
-
 task :default => :test
+
+namespace :db do
+  task :create do
+    # File.expand_path is executed directory of generated Rails app
+    rakefile = File.expand_path('Rakefile', 'test/dummy/')
+    command = "rake -f '%s' db:create" % rakefile
+    sh(command) unless ENV["DISABLE_CREATE"]
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -38,6 +38,22 @@ namespace :db do
     # File.expand_path is executed directory of generated Rails app
     rakefile = File.expand_path('Rakefile', 'test/dummy/')
     command = "rake -f '%s' db:create" % rakefile
-    sh(command) unless ENV["DISABLE_CREATE"]
+    sh(command)
+  end
+
+  task :drop do
+    # File.expand_path is executed directory of generated Rails app
+    rakefile = File.expand_path('Rakefile', 'test/dummy/')
+    command = "rake -f '%s' db:drop" % rakefile
+    sh(command)
+  end
+
+  namespace :test do
+    task :prepare do
+      # File.expand_path is executed directory of generated Rails app
+      rakefile = File.expand_path('Rakefile', 'test/dummy/')
+      command = "rake -f '%s' db:test:prepare" % rakefile
+      sh(command)
+    end
   end
 end

--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -12,7 +12,7 @@ module Sequenced
 
     def set
       return if id_set? || skip?
-      lock_table(record.class)
+      lock_table
       record.send(:"#{column}=", next_id)
     end
 
@@ -46,14 +46,15 @@ module Sequenced
 
   private
 
-    def lock_table(klass)
+    def lock_table
       if postgresql?
-        klass.connection.execute("LOCK TABLE #{klass.table_name} IN EXCLUSIVE MODE")
+        record.class.connection.execute("LOCK TABLE #{record.class.table_name} IN EXCLUSIVE MODE")
       end
     end
 
     def postgresql?
-      ActiveRecord::Base.configurations[Rails.env]['adapter'] == 'postgresql'
+      defined?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter) &&
+        record.class.connection.instance_of?(ActiveRecord::ConnectionAdapters::PostgreSQLAdapter)
     end
 
     def base_relation

--- a/sequenced.gemspec
+++ b/sequenced.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "activerecord", ">= 3.0"
   s.add_development_dependency "rails", ">= 3.1"
-  s.add_development_dependency "sqlite3"
 end

--- a/test/concurrency_test.rb
+++ b/test/concurrency_test.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+# Test Models:
+#
+#   Answer       - :scope => :question_id
+#   Comment      - :scope => :question_id (with an AR default scope)
+#   Invoice      - :scope => :account_id, :start_at => 1000
+#   Product      - :scope => :account_id, :start_at => lambda { |r| r.computed_start_value }
+#   Order        - :scope => :non_existent_column
+#   User         - :scope => :account_id, :column => :custom_sequential_id
+#   Address      - :scope => :account_id ('sequential_id' does not exist)
+#   Email        - :scope => [:emailable_id, :emailable_type]
+#   Subscription - no options
+#   Rating       - :scope => :comment_id, skip: { |r| r.score == 0 }
+#   Monster      - no options
+#   Zombie       - STI, inherits from Monster
+#   Werewolf     - STI, inherits from Monster
+
+#   ConcurrentBadger - scope: :concurrent_burrow_id,
+#                      NOT NULL constraint on sequential_id,
+#                      UNIQUE constraint on sequential_id within concurrent_burrow_id scope
+
+if ENV['DB'] == 'postgresql'
+  class ConcurrencyTest < ActiveSupport::TestCase
+    self.use_transactional_fixtures = false
+
+    def setup
+      ConcurrentBadger.delete_all
+    end
+
+    def teardown
+      ConcurrentBadger.delete_all
+    end
+
+    test "creates records concurrently without data races" do
+      Thread.abort_on_exception = true
+      range = (1..50)
+
+      threads = []
+      range.each do
+        threads << Thread.new do
+          ConcurrentBadger.create!(burrow_id: 1)
+        end
+      end
+
+      threads.each(&:join)
+
+      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      assert_equal range.to_a, sequential_ids
+    end
+
+    test "does not affect saving multiple records within a transaction" do
+      range = (1..10)
+
+      ConcurrentBadger.transaction do
+        range.each do
+          ConcurrentBadger.create!(burrow_id: 1)
+        end
+      end
+
+      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      assert_equal range.to_a, sequential_ids
+    end
+
+    test "does not affect saving multiple records within nested transactons" do
+      range = (1..10)
+
+      ConcurrentBadger.transaction do
+        ConcurrentBadger.transaction do
+          ConcurrentBadger.transaction do
+            range.each do
+              ConcurrentBadger.create!(burrow_id: 1)
+            end
+          end
+        end
+      end
+
+      sequential_ids = ConcurrentBadger.pluck(:sequential_id)
+      assert_equal range.to_a, sequential_ids
+    end
+  end
+end

--- a/test/dummy/app/models/concurrent_badger.rb
+++ b/test/dummy/app/models/concurrent_badger.rb
@@ -1,0 +1,3 @@
+class ConcurrentBadger < ActiveRecord::Base
+  acts_as_sequenced scope: :burrow_id
+end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -1,25 +1,29 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-development:
-  adapter: sqlite3
-  database: db/development.sqlite3
-  pool: 5
-  timeout: 5000
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
+# example_travisci_multi/config/database.yml
+sqlite: &sqlite
   adapter: sqlite3
   database: db/test.sqlite3
-  pool: 5
-  timeout: 5000
 
-production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+mysql: &mysql
+  adapter: mysql2
+  username: root
+  password:
+
+postgresql: &postgresql
+  adapter: postgresql
+  username: postgres
+  password:
+  min_messages: ERROR
+
+defaults: &defaults
   pool: 5
   timeout: 5000
+  host: localhost
+  <<: *<%= ENV['DB'] || "sqlite" %>
+
+development:
+  database: sequenced_test
+  <<: *defaults
+
+test:
+  database: sequenced_test
+  <<: *defaults

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -15,7 +15,7 @@ postgresql: &postgresql
   min_messages: ERROR
 
 defaults: &defaults
-  pool: 5
+  pool: 100
   timeout: 5000
   host: localhost
   <<: *<%= ENV['DB'] || "sqlite" %>

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -22,16 +22,12 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
-  # Log the query plan for queries taking more than this (works
-  # with SQLite, MySQL, and PostgreSQL)
-  config.active_record.auto_explain_threshold_in_seconds = 0.5
-
   # Do not compress assets
   config.assets.compress = false
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Required for Rails >= 4.2
+  config.eager_load = true
 end

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -35,4 +35,7 @@ Dummy::Application.configure do
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Required for Rails >= 4.2
+  config.eager_load = true
 end

--- a/test/dummy/db/migrate/20151120190645_create_concurrent_badgers.rb
+++ b/test/dummy/db/migrate/20151120190645_create_concurrent_badgers.rb
@@ -1,0 +1,10 @@
+class CreateConcurrentBadgers < ActiveRecord::Migration
+  def change
+    create_table :concurrent_badgers do |t|
+      t.integer :sequential_id, null: false
+      t.integer :burrow_id
+    end
+
+    add_index :concurrent_badgers, [:sequential_id, :burrow_id], unique: true, name: 'unique_concurrent'
+  end
+end


### PR DESCRIPTION
Tested with 50 simultaneous connections. This 100% guarantees correctness of the sequential_id in Postgres and makes no change to the previous behavior for other database adapters.

Unfortunately this is not so trivial to implement in MySQL because table locks must be manually released.